### PR TITLE
keep vertex uids when they already exist

### DIFF
--- a/R/SC-model.R
+++ b/R/SC-model.R
@@ -45,7 +45,7 @@ SC.default <- function(x, ...) {
     stop("unable to produce edge form of this data")
   }
   V <- sc_vertex(B)
-  V[["vertex_"]] <- sc_uid(V)
+  if (!"vertex_" %in% names(V)) V[["vertex_"]] <- sc_uid(V)
   ## these are now the edges, but we need to classify which changed direction
   v_0 <- pmin(edge$.vx0, edge$.vx1)
   v_1 <- pmax(edge$.vx0, edge$.vx1)


### PR DESCRIPTION
I'm not sure about the subsequent line
```
  edge[["edge_"]] <- sc_uid(length(unique(edge$u_edge)))[edge$u_edge] 
```
I don't think that can currently be dealt with so simply, right?